### PR TITLE
feat: allow to send `X-Client-Id` headers to nodejs api

### DIFF
--- a/src/code-components/ApiProvider/ApiContext.tsx
+++ b/src/code-components/ApiProvider/ApiContext.tsx
@@ -2,7 +2,6 @@ import { ContextType, createContext, ReactNode } from "react";
 
 export const ApiContext = createContext<{
   clientId?: string;
-  clientVersion?: string;
 }>({});
 
 export function ApiContextProvider({

--- a/src/code-components/ApiProvider/ApiMutationProvider.tsx
+++ b/src/code-components/ApiProvider/ApiMutationProvider.tsx
@@ -41,7 +41,7 @@ export function ApiMutationProvider({
   onLoad,
   onError,
 }: ApiMutationProviderProps) {
-  const { clientId, clientVersion } = useContext(ApiContext);
+  const { clientId } = useContext(ApiContext);
   const actualOnError = useOnError({ alertOnError, onError });
   const response = useSWRMutation<
     any,
@@ -57,7 +57,6 @@ export function ApiMutationProvider({
         query,
         useNodejsApi,
         clientId,
-        clientVersion,
         ...options,
       };
       return fetchApi(fetchOptions).then((data) =>

--- a/src/code-components/ApiProvider/ApiProvider.register.ts
+++ b/src/code-components/ApiProvider/ApiProvider.register.ts
@@ -13,7 +13,6 @@ export function registerApiProvider(
     importName: "ApiContextProvider",
     props: {
       clientId: { type: "string" },
-      clientVersion: { type: "string" },
     },
   });
 

--- a/src/code-components/ApiProvider/ApiProvider.tsx
+++ b/src/code-components/ApiProvider/ApiProvider.tsx
@@ -46,7 +46,7 @@ export type ApiResponse<Data = any, Error = any, Config = any> = SWRResponse<
 >;
 
 export function ApiProvider(props: ApiProviderProps) {
-  const { clientId, clientVersion } = useContext(ApiContext);
+  const { clientId } = useContext(ApiContext);
   const {
     method,
     path,
@@ -79,7 +79,6 @@ export function ApiProvider(props: ApiProviderProps) {
     query,
     useNodejsApi,
     clientId,
-    clientVersion,
   };
   const response = useSWR(
     enabled && interactive ? cacheKey : null,

--- a/src/code-components/ApiProvider/fetchApi.ts
+++ b/src/code-components/ApiProvider/fetchApi.ts
@@ -10,7 +10,6 @@ export interface FetchApiOptions {
   body?: Record<string, any>;
   useNodejsApi?: boolean;
   clientId?: string;
-  clientVersion?: string;
 }
 
 export async function fetchApi<TData>({
@@ -21,7 +20,6 @@ export async function fetchApi<TData>({
   body,
   useNodejsApi,
   clientId,
-  clientVersion,
 }: FetchApiOptions): Promise<TData> {
   const { method: actualMethod, url } = useNodejsApi
     ? buildNewApiUrl({ method, path, query })
@@ -34,10 +32,9 @@ export async function fetchApi<TData>({
       body: body ? JSON.stringify(body) : undefined,
       headers: {
         ...(body ? { "Content-Type": "application/json" } : undefined),
-        ...(useNodejsApi
+        ...(useNodejsApi && clientId
           ? {
               "X-Client-Id": clientId,
-              "X-Client-Version": clientVersion,
             }
           : {}),
         ...headers,


### PR DESCRIPTION
This allows the plasmic application to specify custom value for `X-Client-Id` header that will be added to all nodejs API requests.

![image](https://github.com/user-attachments/assets/5d320c36-dc90-4c2f-a18a-3cdf04be68bc)
