### PR TITLE
fix(ApiProvider): memoize returned object

### DIFF
--- a/src/code-components/ApiProvider/ApiMutationProvider.tsx
+++ b/src/code-components/ApiProvider/ApiMutationProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext } from "react";
+import { ReactNode, useContext, useMemo } from "react";
 import { Arguments } from "swr";
 import useSWRMutation from "swr/mutation";
 import { MemoDataProvider } from "../MemoDataProvider/MemoDataProvider";
@@ -78,8 +78,13 @@ export function ApiMutationProvider({
     throw error;
   }
 
+  const memoResponse = useMemo(() => {
+    return response;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [response.data, response.error, response.isMutating]);
+
   return (
-    <MemoDataProvider name={name} data={response} memoKey={response}>
+    <MemoDataProvider name={name} data={memoResponse} memoKey={memoResponse}>
       {children}
     </MemoDataProvider>
   );

--- a/src/code-components/ApiProvider/useMockedResponse.ts
+++ b/src/code-components/ApiProvider/useMockedResponse.ts
@@ -3,6 +3,7 @@ import { SWRResponse } from "swr";
 import { FetchError } from "./FetchError";
 import { FetchApiOptions } from "./fetchApi";
 import { ResponseTransform } from "./transformResponse";
+import { ApiResponse } from "./ApiProvider";
 
 export enum EditorMode {
   interactive = "interactive",
@@ -19,13 +20,13 @@ export function useMockedResponse<TData>({
   transformResponse,
   fetchOptions,
 }: {
-  response: SWRResponse<TData>;
+  response: ApiResponse<TData>;
   inEditor: boolean;
   editorMode: EditorMode;
   previewData: TData;
   transformResponse: ResponseTransform;
   fetchOptions: FetchApiOptions;
-}): SWRResponse<TData> {
+}): ApiResponse<TData> {
   if (!inEditor) {
     return response;
   }
@@ -33,7 +34,7 @@ export function useMockedResponse<TData>({
   const interactive = editorMode === EditorMode.interactive;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return useMemo((): SWRResponse => {
+  return useMemo((): ApiResponse<TData> => {
     if (interactive) {
       return response;
     }
@@ -43,6 +44,7 @@ export function useMockedResponse<TData>({
         data: undefined,
         error: undefined,
         isLoading: true,
+        isLagging: false,
         isValidating: true,
         mutate: () => new Promise(() => {}),
       };
@@ -57,6 +59,7 @@ export function useMockedResponse<TData>({
           "mocked error for inEditor mode",
         ),
         isLoading: true,
+        isLagging: false,
         isValidating: true,
         mutate: () => new Promise(() => {}),
       };
@@ -66,6 +69,7 @@ export function useMockedResponse<TData>({
       data: transformResponse(previewData, fetchOptions),
       error: undefined,
       isLoading: false,
+      isLagging: false,
       isValidating: false,
       mutate: () => new Promise(() => {}),
     };


### PR DESCRIPTION
Turns out we still had a bug in our `ApiProvider` - it would constantly return a new object (even though no API data nor state has changed), triggering a rerender to all of componetns downwards, as it would keep passing new context to `MemoDataProvider`.

This fixes it - and finally, CAW subsections don't get rerendered if nothing really happens in `CAW/Worksheet`, besides e.g. collapsing a competency section.