### PR TITLE
feat(ApiProvider): option for revalidation on mount

### DIFF
--- a/src/code-components/ApiProvider/ApiProvider.register.ts
+++ b/src/code-components/ApiProvider/ApiProvider.register.ts
@@ -73,6 +73,13 @@ export function registerApiProvider(
         description: "Used when Editor Mode is set to Success State.",
       },
       children: { type: "slot" },
+      revalidateOnMount: {
+        type: "boolean",
+        defaultValue: false,
+        advanced: true,
+        description:
+          "Determines whether data should be re-fetched when a component mounts.",
+      },
       refetchIfStale: {
         type: "boolean",
         defaultValue: true,

--- a/src/code-components/ApiProvider/ApiProvider.tsx
+++ b/src/code-components/ApiProvider/ApiProvider.tsx
@@ -25,6 +25,7 @@ export interface ApiProviderProps {
   editorMode?: EditorMode;
   previewData?: any;
   children: ReactNode;
+  revalidateOnMount?: boolean;
   refetchIfStale?: boolean;
   refetchOnWindowFocus?: boolean;
   refetchOnReconnect?: boolean;
@@ -56,6 +57,7 @@ export function ApiProvider(props: ApiProviderProps) {
     editorMode,
     previewData,
     children,
+    revalidateOnMount,
     refetchIfStale,
     refetchOnWindowFocus,
     refetchOnReconnect,
@@ -83,6 +85,7 @@ export function ApiProvider(props: ApiProviderProps) {
 
   const swrOptions: SWRConfiguration = {
     use: [swrLaggyMiddleware],
+    revalidateOnMount: revalidateOnMount,
     revalidateIfStale: refetchIfStale,
     revalidateOnFocus: refetchOnWindowFocus,
     revalidateOnReconnect: refetchOnReconnect,


### PR DESCRIPTION
This will allow me to refresh the list of messages every time the user enables the Inbox tab

Solution for: https://www.notion.so/Posts-UI-1124d59f776b80be81dcef37ee396187?d=19e4d59f776b8094a0d0001c52946714&pvs=4#19e4d59f776b80e19f68fb29308cfb84

Demo: https://studio.plasmic.app/projects/p5fDqKf3tE9hZs34jWhG2h/-/Homepage?branch=swr-refetchOnMount&arena_type=page&arena=c_aBSG9zuJy0