### PR TITLE
fix(ApiProvider): pass false if enabled is null or undefined (MET-1743)

### DIFF
--- a/src/code-components/ApiProvider/ApiProvider.tsx
+++ b/src/code-components/ApiProvider/ApiProvider.tsx
@@ -149,7 +149,7 @@ function fillProps(props: ApiProviderProps) {
     ...props,
     method: props.method ?? "GET",
     cacheKey: props.cacheKey ?? [props.path, props.query],
-    enabled: props.enabled ?? true,
+    enabled: props.enabled ?? false,
     name: props.name ?? "response",
     editorMode: props.editorMode ?? EditorMode.interactive,
     refetchIfStale: props.refetchIfStale ?? true,


### PR DESCRIPTION
We often rely on checking whether something exists by passing null or undefined to enabled. In such cases, we expect ApiProvider not to call the API. We don’t want to return true but false instead.

More here: [slack](https://fullstackhouse.slack.com/archives/C06BLMD8DQV/p1743573083199209) and in task description

Edit: That's not the point (more at slack link). Closing.