### PR TITLE
fix(RichTextArea): autofocus on value change

### DIFF
--- a/src/code-components/RichTextArea/Editor.tsx
+++ b/src/code-components/RichTextArea/Editor.tsx
@@ -55,7 +55,7 @@ const Editor = forwardRef<Quill | null, EditorProps>(
         const editorHtml = quill.root.innerHTML.trim();
 
         if (value?.trim() !== editorHtml) {
-          quill.clipboard.dangerouslyPasteHTML(value || "");
+          value ? (quill.root.innerHTML = value) : (quill.root.innerHTML = "");
         }
       }
     }, [value]);
@@ -92,7 +92,7 @@ const Editor = forwardRef<Quill | null, EditorProps>(
       }
 
       if (value) {
-        quill.clipboard.dangerouslyPasteHTML(value);
+        quill.root.innerHTML = value;
       }
 
       quill.on(

--- a/src/code-components/RichTextArea/Editor.tsx
+++ b/src/code-components/RichTextArea/Editor.tsx
@@ -55,7 +55,7 @@ const Editor = forwardRef<Quill | null, EditorProps>(
         const editorHtml = quill.root.innerHTML.trim();
 
         if (value?.trim() !== editorHtml) {
-          value ? (quill.root.innerHTML = value) : (quill.root.innerHTML = "");
+          quill.root.innerHTML = value ?? "";
         }
       }
     }, [value]);


### PR DESCRIPTION
`dangerouslyPasteHTML` caused autofocus on the editor with initital value on first render. This, on the other hand, caused the page to scroll to the last RichTextArea in the CAW on open.

https://studio.plasmic.app/projects/p5fDqKf3tE9hZs34jWhG2h/-/test?branch=MET-1700-RichTextArea-playground&arena_type=component&arena=m6glykaLvD56
I added `console.log(window.document.activeElement);` that displays the currently focused element. Before the change it was the last editor rendered. Now it is the body.