### PR TITLE
fix(RichTextArea): editor removes ul list (MET-1700)

### DIFF
--- a/src/code-components/RichTextArea/Editor.tsx
+++ b/src/code-components/RichTextArea/Editor.tsx
@@ -55,7 +55,8 @@ const Editor = forwardRef<Quill | null, EditorProps>(
         const editorHtml = quill.root.innerHTML.trim();
 
         if (value?.trim() !== editorHtml) {
-          quill.root.innerHTML = value ?? "";
+          const contents = quill.clipboard.convert({ html: value ?? "" });
+          quill.setContents(contents);
         }
       }
     }, [value]);
@@ -92,7 +93,8 @@ const Editor = forwardRef<Quill | null, EditorProps>(
       }
 
       if (value) {
-        quill.root.innerHTML = value;
+        const contents = quill.clipboard.convert({ html: value });
+        quill.setContents(contents);
       }
 
       quill.on(


### PR DESCRIPTION
A bug was introduced with the previous change. RichTextArea does not support ul lists.
More here:
https://github.com/slab/quill/issues/2658#issuecomment-503027934