### PR TITLE
refactor(jsonApiMiddleware): don't attempt parsing body if Content-Type header is missing (MET-1860)

### DIFF
--- a/src/code-components/ApiProvider/middlewares/json.ts
+++ b/src/code-components/ApiProvider/middlewares/json.ts
@@ -16,6 +16,11 @@ export const jsonApiMiddleware: ApiMiddleware = {
         );
       }
 
+      const contentType = response.headers.get("Content-Type");
+      if (!contentType) {
+        return null;
+      }
+
       return await parseResponseBody(response);
     } catch (error) {
       if (error instanceof ApiError) {


### PR DESCRIPTION
While we fixed the issue at the .NET side we still have to fix it at the `ApiProvider` level because it attempts to parse the body, even though it's empty & the content type is missing causing the `FetchError`.

![image](https://github.com/user-attachments/assets/a13cb960-afe2-418d-a4d7-6960e423ab49)
