### PR TITLE
feat(HighlightedText): enable `autoEscape` (MET-1909)

### DIFF
--- a/src/code-components/HighlightedText/HighlightedText.tsx
+++ b/src/code-components/HighlightedText/HighlightedText.tsx
@@ -21,6 +21,7 @@ export function HighlightedText({
         textToHighlight={text}
         highlightClassName={highlightClassName}
         caseSensitive={false}
+        autoEscape={true}
       />
     </span>
   );


### PR DESCRIPTION
This pull request introduces a minor update to the `HighlightedText` component. The change ensures that special characters in the highlighted text are escaped automatically to prevent potential rendering issues.

[Demo](https://studio.plasmic.app/projects/p5fDqKf3tE9hZs34jWhG2h/-/HighlightedText?branch=highlight-text-escape&arena_type=component&arena=8gRFpSZ89tAv)
