### PR TITLE
fix(FileInput): reset input after `onChange` call (MET-1960)

### DIFF
--- a/src/code-components/FileInput/FileInput.tsx
+++ b/src/code-components/FileInput/FileInput.tsx
@@ -33,7 +33,8 @@ export function FileInput({
 
     if (valid.length) onChange?.(valid);
     if (invalid.length) onInvalidFileInput?.(invalid);
-    return;
+
+    inputRef.current!.value = "";
   }
 
   function handleClick() {


### PR DESCRIPTION
Currently, we cant upload the same file twice in a row. That is what is causing this (https://github.com/myevaluations/myevals-react-frontend/pull/495#discussion_r2086777988) error.
More about it here: https://stackoverflow.com/questions/26634616/filereader-upload-same-file-again-not-working