### PR TITLE
refactor(useImageUpload): add `width` attribute to all embed images  (MET-1986)

### DIFF
--- a/src/code-components/RichTextArea/useImageUpload.ts
+++ b/src/code-components/RichTextArea/useImageUpload.ts
@@ -89,14 +89,12 @@ function insertImage(quill: Quill, imageUrl: string) {
   let index = quill.getSelection()?.index;
   if (index === undefined || index < 0) index = quill.getLength();
 
-  const delta = new Delta([
+  const delta = new Delta().retain(index).insert(
     {
-      insert: {
-        image: imageUrl,
-      },
-      attributes: { maxWidth: "100%" },
+      image: imageUrl,
     },
-  ]);
+    { width: "100%" },
+  );
 
   quill.updateContents(delta, "user");
   quill.setSelection(index + 1);

--- a/src/code-components/RichTextArea/useImageUpload.ts
+++ b/src/code-components/RichTextArea/useImageUpload.ts
@@ -7,6 +7,7 @@ import { Quill } from "react-quill-new";
 import { useCurrentRef } from "../../common/useCurrentRef";
 import { useQuillOnInit } from "./useQuillOnInit";
 import { ReactQuillPackages } from "./useReactQuillPackages";
+import Delta from "quill-delta";
 
 const acceptedImageTypes = [
   "image/apng",
@@ -87,7 +88,18 @@ export function useImageUpload({
 function insertImage(quill: Quill, imageUrl: string) {
   let index = quill.getSelection()?.index;
   if (index === undefined || index < 0) index = quill.getLength();
-  quill.insertEmbed(index, "image", imageUrl, "user");
+
+  const delta = new Delta([
+    {
+      insert: {
+        image: imageUrl,
+      },
+      attributes: { maxWidth: "100%" },
+    },
+  ]);
+
+  quill.updateContents(delta, "user");
+  quill.setSelection(index + 1);
 }
 
 function useToolbarImageHandler({


### PR DESCRIPTION
[Demo](https://studio.plasmic.app/projects/p5fDqKf3tE9hZs34jWhG2h/-/RichTextAreaDemo?branch=rich-text-area-img-width&arena_type=component&arena=Tclk6lVsI0fo)