### PR TITLE
fix(FormProvider): ensure formKey properly remounts form state (MET-2671)

### DIFF
--- a/src/code-components/form/FormProvider.tsx
+++ b/src/code-components/form/FormProvider.tsx
@@ -17,9 +17,10 @@ export interface FormProviderProps {
   formKey?: string;
 }
 
-interface FormWrapperProps extends Omit<FormProviderProps, "formKey"> {}
+interface FormProviderWithoutKeyProps
+  extends Omit<FormProviderProps, "formKey"> {}
 
-function FormWrapper({
+function FormProviderWithoutKey({
   contextName,
   defaultValues,
   values,
@@ -29,7 +30,7 @@ function FormWrapper({
   shouldUnregister,
   zodValidationSchema,
   children,
-}: FormWrapperProps) {
+}: FormProviderWithoutKeyProps) {
   const form = useForm({
     defaultValues,
     values,
@@ -49,31 +50,6 @@ function FormWrapper({
   );
 }
 
-export function FormProvider({
-  contextName,
-  defaultValues,
-  values,
-  mode,
-  reValidateMode,
-  resetOptions,
-  shouldUnregister,
-  zodValidationSchema,
-  children,
-  formKey,
-}: FormProviderProps) {
-  return (
-    <FormWrapper
-      key={formKey}
-      contextName={contextName}
-      defaultValues={defaultValues}
-      values={values}
-      mode={mode}
-      reValidateMode={reValidateMode}
-      resetOptions={resetOptions}
-      shouldUnregister={shouldUnregister}
-      zodValidationSchema={zodValidationSchema}
-    >
-      {children}
-    </FormWrapper>
-  );
+export function FormProvider({ formKey, ...props }: FormProviderProps) {
+  return <FormProviderWithoutKey key={formKey} {...props} />;
 }

--- a/src/code-components/form/FormProvider.tsx
+++ b/src/code-components/form/FormProvider.tsx
@@ -17,7 +17,9 @@ export interface FormProviderProps {
   formKey?: string;
 }
 
-export function FormProvider({
+interface FormWrapperProps extends Omit<FormProviderProps, "formKey"> {}
+
+function FormWrapper({
   contextName,
   defaultValues,
   values,
@@ -27,8 +29,7 @@ export function FormProvider({
   shouldUnregister,
   zodValidationSchema,
   children,
-  formKey,
-}: FormProviderProps) {
+}: FormWrapperProps) {
   const form = useForm({
     defaultValues,
     values,
@@ -42,13 +43,37 @@ export function FormProvider({
   });
 
   return (
-    <MemoDataProvider
-      name={contextName}
-      data={form}
-      deps={[form]}
-      key={formKey}
-    >
+    <MemoDataProvider name={contextName} data={form} deps={[form]}>
       {children}
     </MemoDataProvider>
+  );
+}
+
+export function FormProvider({
+  contextName,
+  defaultValues,
+  values,
+  mode,
+  reValidateMode,
+  resetOptions,
+  shouldUnregister,
+  zodValidationSchema,
+  children,
+  formKey,
+}: FormProviderProps) {
+  return (
+    <FormWrapper
+      key={formKey}
+      contextName={contextName}
+      defaultValues={defaultValues}
+      values={values}
+      mode={mode}
+      reValidateMode={reValidateMode}
+      resetOptions={resetOptions}
+      shouldUnregister={shouldUnregister}
+      zodValidationSchema={zodValidationSchema}
+    >
+      {children}
+    </FormWrapper>
   );
 }


### PR DESCRIPTION
## Summary
Fixed the FormProvider formKey behavior to properly reset form state when the formKey prop changes.

## Problem
The `useForm()` hook was being called directly in the FormProvider component. Even when the `formKey` prop changed, the hook's memoized state persisted because React wasn't unmounting and remounting the component. This caused dirty form field values to remain even when form values should have been reset.

## Solution
Created an internal `FormProviderWithoutKey` component that:
1. Contains the `useForm()` hook call
2. Wraps the `MemoDataProvider`
3. Receives the `formKey` as its React `key` prop from the parent `FormProvider`

When `formKey` changes, React will:
- Unmount the old `FormProviderWithoutKey` instance (destroying the form state)
- Mount a new `FormProviderWithoutKey` instance (creating fresh form state)

## Changes
- Created `FormProviderWithoutKey` component that handles form creation
- Modified `FormProvider` to render `FormProviderWithoutKey` with the `formKey` as the React `key` prop
- Used spread operator for cleaner prop passing
- The outer interface of `FormProvider` remains unchanged for backward compatibility

## Related
- Fixes https://www.notion.so/fullstackhouse/Dirty-form-field-values-are-left-even-when-form-values-are-changed-2a14d59f776b80bcb8e2c81626c7e121
- Task: MET-2671

🤖 Generated with [Claude Code](https://claude.com/claude-code)