### PR TITLE
feat(Combobox): add disabled property to options (MET-2795)

### DIFF
--- a/src/code-components/Combobox/Combobox.register.ts
+++ b/src/code-components/Combobox/Combobox.register.ts
@@ -136,8 +136,24 @@ export function registerCombobox(
             selector: `${selectedSelector}${disabledSelector}`,
           },
           {
+            label: "Selected & Highlighted & Disabled",
+            selector: `${selectedSelector}${highlightSelector}${disabledSelector}`,
+          },
+          {
             label: "Active & Selected & Highlighted",
             selector: `${activeSelector}${selectedSelector}${highlightSelector}`,
+          },
+          {
+            label: "Active & Selected & Disabled",
+            selector: `${activeSelector}${selectedSelector}${disabledSelector}`,
+          },
+          {
+            label: "Active & Highlighted & Disabled",
+            selector: `${activeSelector}${highlightSelector}${disabledSelector}`,
+          },
+          {
+            label: "Active & Selected & Highlighted & Disabled",
+            selector: `${activeSelector}${selectedSelector}${highlightSelector}${disabledSelector}`,
           },
         ],
       },

--- a/src/code-components/Combobox/Combobox.register.ts
+++ b/src/code-components/Combobox/Combobox.register.ts
@@ -8,6 +8,7 @@ export function registerCombobox(
   const activeSelector = "[data-headlessui-state*=active]";
   const selectedSelector = "[aria-selected=true]";
   const highlightSelector = "[data-highlight=true]";
+  const disabledSelector = "[aria-disabled=true]";
 
   plasmic.registerComponent(Combobox, {
     name: "RawCombobox",
@@ -111,6 +112,10 @@ export function registerCombobox(
             selector: highlightSelector,
           },
           {
+            label: "Disabled",
+            selector: disabledSelector,
+          },
+          {
             label: "Active & Selected",
             selector: `${activeSelector}${selectedSelector}`,
           },
@@ -119,8 +124,16 @@ export function registerCombobox(
             selector: `${activeSelector}${highlightSelector}`,
           },
           {
+            label: "Active & Disabled",
+            selector: `${activeSelector}${disabledSelector}`,
+          },
+          {
             label: "Selected & Highlighted",
             selector: `${selectedSelector}${highlightSelector}`,
+          },
+          {
+            label: "Selected & Disabled",
+            selector: `${selectedSelector}${disabledSelector}`,
           },
           {
             label: "Active & Selected & Highlighted",

--- a/src/code-components/Combobox/Combobox.tsx
+++ b/src/code-components/Combobox/Combobox.tsx
@@ -46,6 +46,7 @@ export interface ComboboxOption {
   value: ComboboxValue;
   highlight?: boolean;
   group?: string;
+  disabled?: boolean;
 }
 
 export interface OptionGroup {
@@ -203,9 +204,11 @@ export function Combobox({
                           <HeadlessCombobox.Option
                             key={optionIndex}
                             value={option}
+                            disabled={option.disabled}
                             data-highlight={
                               option.highlight ? "true" : undefined
                             }
+                            data-disabled={option.disabled ? "true" : undefined}
                             className={optionClassName}
                           >
                             <p className={labelClassName}>


### PR DESCRIPTION
This pull request enhances the `Combobox` component by introducing support for disabled options and updating the registration logic to allow for more granular styling and state handling. The most significant changes add a `disabled` state to options and expand the set of selectors available for styling combinations of `active`, `selected`, `highlighted`, and `disabled` states.

**Support for Disabled Options and Expanded Styling:**

* Added a `disabled` property to the `ComboboxOption` interface, enabling options to be marked as disabled.
* Updated the rendering of `HeadlessCombobox.Option` to pass the `disabled` prop and set a `data-disabled` attribute based on the option's state.

**Expanded State Selectors for Styling:**

* Introduced a new `disabledSelector` and registered it as a possible state for styling in the combobox registration. [[1]](diffhunk://#diff-dd10a01072ccef94773815629d904b25d8cf7ef098c755a6f7e431bfe58c84a4R11) [[2]](diffhunk://#diff-dd10a01072ccef94773815629d904b25d8cf7ef098c755a6f7e431bfe58c84a4R114-R117)
* Added new state combinations involving `disabled` (e.g., "Active & Disabled", "Selected & Disabled", and all permutations with `active`, `selected`, `highlighted`, and `disabled`) to the `states` array in the combobox registration, allowing for more precise styling in Plasmic.