### PR TITLE
feat(Combobox): add per-option optionLeftIcon slot with `$ctx.option data` (MET-2954)

### DIFF
--- a/src/code-components/Combobox/Combobox.register.ts
+++ b/src/code-components/Combobox/Combobox.register.ts
@@ -54,6 +54,9 @@ export function registerCombobox(
       leftIcon: { type: "slot" },
       rightIcon: { type: "slot" },
       footer: { type: "slot" },
+      optionLeftIcon: {
+        type: "slot",
+      },
       inputWrapperClassName: {
         type: "class",
         selectors: [
@@ -96,6 +99,8 @@ export function registerCombobox(
         type: "class",
       },
       optionsClassName: { type: "class" },
+      optionLeftIconClassName: { type: "class" },
+      optionContentClassName: { type: "class" },
       optionClassName: {
         type: "class",
         selectors: [
@@ -175,5 +180,6 @@ export function registerCombobox(
         onChangeProp: "onChange",
       },
     },
+    providesData: true,
   });
 }

--- a/src/code-components/Combobox/Combobox.tsx
+++ b/src/code-components/Combobox/Combobox.tsx
@@ -1,6 +1,7 @@
 import { Combobox as HeadlessCombobox, Transition } from "@headlessui/react";
 import { useState, useRef, Fragment, ReactNode } from "react";
 
+import { MemoDataProvider } from "../MemoDataProvider/MemoDataProvider";
 import styles from "./Combobox.module.css";
 import { HighlightQueryValue } from "./HighlightQueryValue";
 import { groupOptions } from "./utils";
@@ -19,6 +20,7 @@ interface ComboboxProps {
   rightIcon: ReactNode;
   footer?: ReactNode;
   options?: ComboboxOption[];
+  optionLeftIcon?: ReactNode;
   disabled?: boolean;
   "aria-label"?: string;
   "aria-labelledby"?: string;
@@ -31,6 +33,8 @@ interface ComboboxProps {
   emptyOptionClassName?: string;
   optionsClassName?: string;
   optionClassName?: string;
+  optionLeftIconClassName?: string;
+  optionContentClassName?: string;
   groupClassName?: string;
   labelClassName?: string;
   searchValueClassName?: string;
@@ -62,6 +66,7 @@ export function Combobox({
   rightIcon,
   footer,
   options,
+  optionLeftIcon,
   disabled,
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledBy,
@@ -75,6 +80,8 @@ export function Combobox({
   emptyOptionClassName,
   optionsClassName,
   optionClassName,
+  optionLeftIconClassName,
+  optionContentClassName,
   groupClassName,
   labelClassName,
   searchValueClassName,
@@ -211,27 +218,40 @@ export function Combobox({
                             data-disabled={option.disabled ? "true" : undefined}
                             className={optionClassName}
                           >
-                            <p className={labelClassName}>
-                              <HighlightQueryValue
-                                text={option.label ?? String(option.value)}
-                                query={query}
-                                queryClassName={searchValueClassName}
-                              />
-                            </p>
-                            {option.description ? (
-                              <p
-                                data-highlight={
-                                  option.highlight ? "true" : undefined
-                                }
-                                className={descriptionClassName}
+                            {optionLeftIcon ? (
+                              <MemoDataProvider
+                                name="option"
+                                data={option}
+                                deps={[option]}
                               >
+                                <div className={optionLeftIconClassName}>
+                                  {optionLeftIcon}
+                                </div>
+                              </MemoDataProvider>
+                            ) : null}
+                            <div className={optionContentClassName}>
+                              <p className={labelClassName}>
                                 <HighlightQueryValue
-                                  text={option.description}
+                                  text={option.label ?? String(option.value)}
                                   query={query}
                                   queryClassName={searchValueClassName}
                                 />
                               </p>
-                            ) : null}
+                              {option.description ? (
+                                <p
+                                  data-highlight={
+                                    option.highlight ? "true" : undefined
+                                  }
+                                  className={descriptionClassName}
+                                >
+                                  <HighlightQueryValue
+                                    text={option.description}
+                                    query={query}
+                                    queryClassName={searchValueClassName}
+                                  />
+                                </p>
+                              ) : null}
+                            </div>
                           </HeadlessCombobox.Option>
                         ))}
                       </Fragment>


### PR DESCRIPTION
## What

Adds an `optionLeftIcon` render slot to `RawCombobox`, rendered once per option. Each option is wrapped in a `MemoDataProvider` exposing the current option as `$ctx.option`, so the slot content adapts per option (e.g. render a status icon driven by the option's data) without hardcoding anything in the component.

## Changes

- **New props**: `optionLeftIcon` (slot), `optionLeftIconClassName`, `optionContentClassName`
- **`providesData: true`** so Plasmic Studio surfaces `$ctx.option` in the data picker inside the slot
- Label + description wrapped in `optionContentClassName` so the icon can sit left while text stays a column (style `optionClassName` as a flex row)

## Usage

```tsx
<Combobox
  options={[{ label: 'Demographics', value: 'demo', status: 'complete' }]}
  optionLeftIcon={<SectionStatus status={$ctx.option.status} />}
/>
```

In Studio: drop a component into the `optionLeftIcon` slot and bind its props to `$ctx.option.*`.

## Notes

- `optionContentClassName` wrapper renders even when no icon is set (harmless extra div; needed for the flex layout).
- Runtime behavior of the dropdown is unchanged.