### PR TITLE
feat(HighlightedText): support multiple highlight words

### DIFF
--- a/src/code-components/HighlightedText/HighLightedText.register.ts
+++ b/src/code-components/HighlightedText/HighLightedText.register.ts
@@ -16,7 +16,8 @@ export function registerHighlightedText(
       },
       highlight: {
         type: "string",
-        description: "The substring to highlight (case insensitive)",
+        description:
+          'Substring to highlight (case insensitive). For multiple words, use a dynamic value with a string array, e.g. ["APE", "GME"].',
       },
       textClassName: {
         type: "class",

--- a/src/code-components/HighlightedText/HighlightedText.tsx
+++ b/src/code-components/HighlightedText/HighlightedText.tsx
@@ -3,7 +3,7 @@ import Highlighter from "react-highlight-words";
 
 interface HighlightedTextProps {
   text: string;
-  highlight: string;
+  highlight: string | string[];
   textClassName?: string;
   highlightClassName?: string;
 }
@@ -14,10 +14,11 @@ export function HighlightedText({
   textClassName,
   highlightClassName,
 }: HighlightedTextProps) {
+  const searchWords = Array.isArray(highlight) ? highlight : [highlight];
   return (
     <span className={textClassName}>
       <Highlighter
-        searchWords={[highlight]}
+        searchWords={searchWords}
         textToHighlight={text}
         highlightClassName={highlightClassName}
         caseSensitive={false}


### PR DESCRIPTION
## What

`HighlightedText` now accepts `string | string[]` for the `highlight` prop, so multiple words can be highlighted in one pass (e.g. `["APE", "GME"]`).

## Why

`react-highlight-words` doesn't split on spaces and `autoEscape` treats each search word as a literal, so a single string can only ever match one phrase. Passing an array is the only way to highlight several distinct words.

## Changes

- `highlight: string | string[]` — normalized internally to an array
- Register description documents passing an array via a dynamic value

## Compatibility

Backward compatible — existing single-string callers are unchanged.

## Usage

```tsx
<HighlightedText
  text="APE overview for the GME department"
  highlight={["APE", "GME"]}
/>
```